### PR TITLE
Add publicsuffix-elixir to the list of libraries

### DIFF
--- a/learn/index.html
+++ b/learn/index.html
@@ -149,6 +149,9 @@
             C: <a href="http://www.github.com/stricaud/faup">Faup</a>, a command line tool with a C library and Python bindings
         </p>
         <p>
+            Elixir: <a href="https://github.com/seomoz/publicsuffix-elixir">publicsuffix-elixir</a>
+        </p>
+        <p>
             Erlang: <a href="https://github.com/sinkovsky/publicsuffix_erlang">publicsuffix_erlang</a>
         </p>
         <p>


### PR DESCRIPTION
We've made https://github.com/seomoz/publicsuffix-elixir available for Elixir developers, and would like to add it to the list of Public Suffix libraries.
