### PR TITLE
Fix Qt name and URL

### DIFF
--- a/learn/index.html
+++ b/learn/index.html
@@ -121,7 +121,7 @@
             Other Apps
         </h4>
         <p>
-            <a href="http://qt.nokia.com/">QT</a> uses it to restrict cookie setting from version 4.7.2 onwards.
+            <a href="https://www.qt.io/">Qt</a> uses it to restrict cookie setting from version 4.7.2 onwards.
         </p>
         <p>
             <a href="http://www.whoismind.com/">WhoisMind</a> uses it to get the domain name out of inputted URLs.


### PR DESCRIPTION
The *Qt* link on the *Learn* page is outdated and doesn’t work. Furthermore, its spelling is wrong (it should be _Qt_ instead of _QT_).