### PR TITLE
Link to GitHub list file

### DIFF
--- a/list/index.html
+++ b/list/index.html
@@ -38,13 +38,8 @@
         <p>
             The list is kept in source code control on <a href="https://github.com/publicsuffix/list">Github</a>. You can read more information on the format the list uses below. <strong>Please note that the list is encoded using UTF-8.</strong>
         </p>
-        <p>The copy on publicsuffix.org, linked below, is updated daily from Github. If you wish to make your app download an updated list periodically,
-        <strong>please use this URL and have your app download the list no more than once per day</strong>.
-        (The list usually changes a few times per week; more frequent downloading is pointless and
-        hammers our servers.)</p>
-        
         <div class="button">
-            <a href="public_suffix_list.dat">See the list</a>
+            <a href="https://raw.githubusercontent.com/publicsuffix/list/master/public_suffix_list.dat">See the list</a>
         </div>
         <p>
             To be kept informed of changes to the list, you can subscribe to an <a href="https://github.com/publicsuffix/list/commits/master.atom">Atom change feed</a> in your favourite feed reader.


### PR DESCRIPTION
The list on a website server is not updated anymore. Let's link to the list file in GitHub repository.