### PR TITLE
Replace deprecated Python package "publicsuffix"

### DIFF
--- a/learn/index.html
+++ b/learn/index.html
@@ -203,7 +203,7 @@
             PHP: <a href="https://github.com/layershifter/TLDExtract">TLDExtract</a>
         </p>
         <p>
-            Python: <a href="https://pypi.python.org/pypi/publicsuffix/">publicsuffix</a>
+            Python: <a href="https://pypi.python.org/pypi/publicsuffix2/">publicsuffix2</a>
         </p>
         <p>
             Python: <a href="https://pypi.python.org/pypi/publicsuffixlist">publicsuffixlist</a>


### PR DESCRIPTION
https://publicsuffix.org/learn/ lists under Libraries: "Python: [publicsuffix](https://pypi.org/project/publicsuffix/)". However, the current (1.1.1) release on PyPI has a deprecation warning.

> Please don’t use this module. It is provided for historical reasons only. New code should instead use one of the other libraries that provide similar functionality. For example:
> 
> * publicsuffix2 [links to https://pypi.org/project/publicsuffix2/]
> * publicsuffixlist [already on the list]

This tacks a 2 on the end to point to the maintained fork of the original. GH repo: https://github.com/nexb/python-publicsuffix2