### PR TITLE
Remove WhoisMind.com from /learn

### DIFF
--- a/learn/index.html
+++ b/learn/index.html
@@ -127,9 +127,6 @@
             <a href="https://www.qt.io/">Qt</a> uses it to restrict cookie setting from version 4.7.2 onwards.
         </p>
         <p>
-            <a href="http://www.whoismind.com/">WhoisMind</a> uses it to get the domain name out of inputted URLs.
-        </p>
-        <p>
             <a href="https://github.com/crawler-commons/crawler-commons">Crawler-Commons</a> is a suite of tools for building a web crawler, and it uses the PSL.
         </p>
 


### PR DESCRIPTION
Remove WhoisMind.com from the list of usages of the PSL in `/learn`, it's some kind of tracking and redirect-infested malware site now