### PR TITLE
Add GitHub Action to deploy site to Google Cloud

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -1,0 +1,57 @@
+---
+name: deploy website
+on:
+  workflow_dispatch: {}
+  workflow_call:
+    secrets:
+      GCP_PROJECT_NAME:
+        required: true
+      BUCKET_NAME:
+        required: true
+      WIP_PROJECT_ID:
+        required: true
+  push:
+    branches:
+      - master
+
+jobs:
+  upload-website:
+    name: Build and deploy website
+    environment: website
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout publicsuffix/publicsuffix.org
+        uses: actions/checkout@v3
+        with:
+          repository: publicsuffix/publicsuffix.org
+          path: publicsuffix.org
+
+      - name: Checkout publicsuffix/list
+        uses: actions/checkout@v3
+        with:
+          repository: publicsuffix/list
+          path: list
+
+      - name: Authenticate with GCP
+        uses: google-github-actions/auth@v0
+        with:
+          token_format: access_token
+          service_account: deploy-website@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com
+          workload_identity_provider: projects/${{ secrets.WIP_PROJECT_ID }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions          
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v1
+
+      - name: Populate list in publicsuffix.org
+        run: |-
+          cp list/public_suffix_list.dat publicsuffix.org/list/
+          cp list/public_suffix_list.dat publicsuffix.org/list/effective_tld_names.dat
+
+      - name: Deploy website
+        run: |-
+          gsutil -m -q rsync -d -r -x ".git" publicsuffix.org/ gs://${{ secrets.BUCKET_NAME }}/


### PR DESCRIPTION
Hi Folks,

This PR adds the GitHub Action to deploy the static site including the list to Google Cloud.

The workflow is structure as is so we can reuse it later in the `publicsuffix/list` repository to trigger site updates also from there.

Base functionally stays the same although behaving slightly different:
- In the past the bucket sync was more an addition rather than a sync (thus not deleting objects from the bucket when they were removed from the repository) which now has changed. All objects removed from the repository also will be removed from the bucket (as I think it was intended).
- We exclude the `.git` folder from the sync. Should you need to adjust that filter keep in mind that files that are present in the bucket will not be removed there when added to the exclusion list as `gsutil` does not have a `--delete-excluded` flag.

The workflow is intended to run on:
- push/merge to master
- manual trigger

and allows to be included in other repositories (although only `publicsuffix/list` and `publicsuffix/publicsuffix.org` are authorized via WIP).

Let me know what you think!

Cheers,
Robert



This fixes #33 

Signed-off-by: Robert Müller <rmuller@mozilla.com>