### PR TITLE
Add concurrency for workflow

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -20,6 +20,10 @@ jobs:
     environment: website
     runs-on: ubuntu-latest
 
+    concurrency:
+      group: ${{ github.workflow }}
+      cancel-in-progress: true
+
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -14,15 +14,15 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   upload-website:
     name: Build and deploy website
     environment: website
     runs-on: ubuntu-latest
-
-    concurrency:
-      group: ${{ github.workflow }}
-      cancel-in-progress: true
 
     permissions:
       contents: read


### PR DESCRIPTION
Add concurrency to avoid mixed state in sync job.

Signed-off-by: Robert Müller <rmuller@mozilla.com>