### PR TITLE
Add Cache-Control header to files

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -55,3 +55,4 @@ jobs:
       - name: Deploy website
         run: |-
           gsutil -m -q rsync -d -r -x ".git" publicsuffix.org/ gs://${{ secrets.BUCKET_NAME }}/
+          gsutil -m -q setmeta -h "Cache-Control:public, max-age=86400" gs://${{ secrets.BUCKET_NAME }}/**


### PR DESCRIPTION
Set the `Cache-Control` header for all files in the bucket to ensure correct caching.

Signed-off-by: Robert Müller <rmuller@mozilla.com>