### PR TITLE
Remove Python: dnspy from libraries list

### DIFF
--- a/learn/index.html
+++ b/learn/index.html
@@ -206,9 +206,6 @@
             Python: <a href="https://pypi.python.org/pypi/publicsuffixlist">publicsuffixlist</a>
         </p>
         <p>
-            Python: <a href="https://pypi.python.org/pypi/dnspy/">dnspy</a> - claims to be more flexible.
-        </p>
-        <p>
             Python: <a href="https://pypi.python.org/pypi/tldextract/">tldextract</a>
         </p>
         <p>


### PR DESCRIPTION
- The package contains an embedded copy of the list, but has not updated in five years. 
- It has an update feature, but it can only be triggered programmatically (not from the tool's command line)
- The update URL hardcoded into the library points to mxr.mozilla.org.

There are multiple other high-quality, actively-updating libraries listed for Python. To point any potential users to this one, instead, would be doing them a disservice.