### PR TITLE
Update cookies documentation

### DIFF
--- a/learn/index.html
+++ b/learn/index.html
@@ -45,7 +45,7 @@
             Since there was and remains no algorithmic method of finding the highest level at which a domain may be registered for a particular top-level domain (the policies differ with each registry), the only method is to create a list. This is the aim of the Public Suffix List.
         </p>
         <p>
-            Software using the Public Suffix List will be able to determine cookie inheritance boundaries between domains, preventing cookies set on one domain from being accessible to other domains under the same public suffix. This protects users from cross-domain tracking while still allowing individual domains to set their own cookies.
+            Software using the Public Suffix List will be able to determine cookie inheritance boundaries between domains, preventing cookies set on one domain from being accessible to other domains under the same public suffix. This protects users from cross-domain cookies setting while still allowing individual domains to set their own cookies.
         </p>
         <p>
             As well as this, the Public Suffix List can also be used to support features such as site grouping in browsers. By knowing where the user-controlled section of the domain name begins and ends, browsers can group cookies and history entries by site in a way that couldn't easily be done before.

--- a/learn/index.html
+++ b/learn/index.html
@@ -45,7 +45,7 @@
             Since there was and remains no algorithmic method of finding the highest level at which a domain may be registered for a particular top-level domain (the policies differ with each registry), the only method is to create a list. This is the aim of the Public Suffix List.
         </p>
         <p>
-            Software using the Public Suffix List will be able to determine where cookies may and may not be set, protecting the user from being tracked across sites.
+            Software using the Public Suffix List will be able to determine cookie inheritance boundaries between domains, preventing cookies set on one domain from being accessible to other domains under the same public suffix. This protects users from cross-domain tracking while still allowing individual domains to set their own cookies.
         </p>
         <p>
             As well as this, the Public Suffix List can also be used to support features such as site grouping in browsers. By knowing where the user-controlled section of the domain name begins and ends, browsers can group cookies and history entries by site in a way that couldn't easily be done before.


### PR DESCRIPTION
This PR attempts to fix publicsuffix/list#2241

Updating documentation to:

`Software using the Public Suffix List will be able to determine cookie inheritance boundaries between domains, preventing cookies set on one domain from being accessible to other domains under the same public suffix. This protects users from cross-domain cookies setting while still allowing individual domains to set their own cookies.`

---

Observations from Chromium and Firefox:

1. We can indeed set cookies on a public suffix (`suffix.tld`)
3. As expected, `subdomain1.suffix.tld` and `subdomain2.suffix.tld` **cannot** set cookies on each other.
4. As expected, `subdomain1.suffix.tld` can set cookies on `sub.subdomain1.suffix.tld`.
5. As expected, `subdomain1.suffix.tld` and `suffix.tld` **cannot** set cookies on each other.

The documentation's current wording suggests that the PSL prevents cookie-setting entirely on public suffixes, when in reality it only prevents cookie sharing/inheritance between separate registrable domains under that public suffix. This is an important distinction that the documentation fails to make clear. A more accurate description would explain that the PSL helps prevent cookies set on one domain from being accessible to other domains under the same public suffix.
