### PR TITLE
Add C++ Upa URL to list of libraries

### DIFF
--- a/learn/index.html
+++ b/learn/index.html
@@ -146,7 +146,7 @@
             C#: <a href="https://github.com/tinohager/Nager.PublicSuffix">Nager.PublicSuffix</a>
         </p>
         <p>
-            C++: <a href="https://github.com/upa-url/upa">Upa URL</a> - WHATWG compliant URL parser library with Public Suffix List functionality
+            C++: <a href="https://github.com/upa-url/upa">Upa URL</a>
         </p>
         <p>
             Elixir: <a href="https://github.com/seomoz/publicsuffix-elixir">publicsuffix-elixir</a>

--- a/learn/index.html
+++ b/learn/index.html
@@ -146,6 +146,9 @@
             C#: <a href="https://github.com/tinohager/Nager.PublicSuffix">Nager.PublicSuffix</a>
         </p>
         <p>
+            C++: <a href="https://github.com/upa-url/upa">Upa URL</a> - WHATWG compliant URL parser library with Public Suffix List functionality
+        </p>
+        <p>
             Elixir: <a href="https://github.com/seomoz/publicsuffix-elixir">publicsuffix-elixir</a>
         </p>
         <p>


### PR DESCRIPTION
Upa URL library has `upa::public_suffix_list` class to get public suffix, registrable domain and other information about provided domain.

Reference: https://upa-url.github.io/docs/main/classupa_1_1public__suffix__list.html