### PR TITLE
Update Elixir link to public_sufx repository

### DIFF
--- a/learn/index.html
+++ b/learn/index.html
@@ -156,7 +156,7 @@
 
         <h4>Elixir</h4>
         <ul>
-            <li><a href="https://github.com/seomoz/publicsuffix-elixir">publicsuffix-elixir</a></li>
+            <li><a href="https://github.com/reisub/public_sufx">public_sufx</a></li>
         </ul>
 
         <h4>Erlang</h4>


### PR DESCRIPTION
The original repo is no longer maintained, this is now the canonical fork.
I'm the maintainer of the fork.

You can see some context around this in:
https://github.com/axelson/publicsuffix-elixir/issues/2

hex.pm link:
https://hex.pm/packages/public_sufx