### PR TITLE
Remove KKDomain from library list

### DIFF
--- a/learn/index.html
+++ b/learn/index.html
@@ -204,11 +204,6 @@
             <li><a href="https://github.com/louislouw/Louw.PublicSuffix">Louw.PublicSuffix</a></li>
         </ul>
 
-        <h4>Objective-C</h4>
-        <ul>
-            <li><a href="https://github.com/kejinlu/KKDomain">KKDomain</a></li>
-        </ul>
-
         <h4>Perl</h4>
         <ul>
             <li><a href="https://metacpan.org/pod/Domain::PublicSuffix">Domain::PublicSuffix</a></li>


### PR DESCRIPTION
This is library didn't have any commits since 2014. It also ships the PSL list from that era in a custom format https://github.com/kejinlu/KKDomain/blob/master/KKDomain/Resources/etld.plist and doesn't specify any way of using a provided PSL list.