### PR TITLE
Remove regdom4j from library list

### DIFF
--- a/learn/index.html
+++ b/learn/index.html
@@ -183,7 +183,6 @@
 
         <h4>Java</h4>
         <ul>
-            <li><a href="https://github.com/hamano/regdom4j/">regdom-libs</a></li>
             <li><a href="https://github.com/google/guava">Guava</a> - Google's core Java library has a <a href="https://google.github.io/guava/releases/snapshot/api/docs/com/google/common/net/InternetDomainName.html">PSL-using class</a></li>
             <li><a href="https://github.com/whois-server-list/public-suffix-list">public-suffix-list</a></li>
         </ul>


### PR DESCRIPTION
This is library didn't have any commits since 2020. It also ships the PSL list from 2015 in a custom format https://github.com/hamano/regdom4j/blob/master/src/main/resources/effectiveTLDs.xml and doesn't specify any way of using a provided PSL list.