### PR TITLE
Update pslr link to its GitLab repository

### DIFF
--- a/learn/index.html
+++ b/learn/index.html
@@ -228,7 +228,7 @@
 
         <h4>R</h4>
         <ul>
-            <li><a href="https://github.com/bart-turczynski/pslr">pslr</a></li>
+            <li><a href="https://gitlab.com/bart-turczynski/pslr">pslr</a></li>
         </ul>
 
         <h4>Raku</h4>


### PR DESCRIPTION
The `pslr` R library has moved from GitHub to GitLab. The URL currently listed under **R** on https://publicsuffix.org/learn/ no longer resolves, so that catalog entry is a dead link for every visitor.

Same project and same maintainer as the entry added in #63 — only the hosting location changed. No other files touched.

A note on the author, since it differs from #63: I filed that PR from `bart-turczynski`, which I no longer have access to — that is also why the old link 404s. `bartturczynski` is my current account. Happy to verify ownership of the GitLab project any way you prefer; I can push a nonce of your choosing to the repository, or reply from the address in its
`DESCRIPTION`.
